### PR TITLE
[dmav_v1_0_validierung] Anpassung zu Modelldou und E-Mail von swisstopo

### DIFF
--- a/DMAV_V1_0_Validierung.ili
+++ b/DMAV_V1_0_Validierung.ili
@@ -253,12 +253,12 @@ IMPORTS DMAV_Gebaeudeadressen_V1_0;
                 (Einzelobjektart == #Silo_Turm_Gasometer) => ((objectCount(Flaechenelement) > 0) AND (objectCount(Linienelement) == 0) AND (objectCount(Punktelement) == 0))
             );
 
-            !!@ ilivalid.msg="Bei Art=Landungssteg muss die Geometrie in Flaechenelement sein";
+            !!@ ilivalid.msg="Bei Art=Landungssteg darf die Geometrie nicht in Punktelement sein";
             !!@ ilivalid.msg_de="Bei Art=Landungssteg muss die Geometrie in Flaechenelement sein";
             !!@ ilivalid.msg_fr="Pour les objets du Genre=Debarcadere, il faut définir la géométrie dans la table Element_surfacique";
             !!@ ilivalid.msg_it="Per il genere debarcadero la geometria deve essere con superficie";
             MANDATORY CONSTRAINT CH051660: (
-                (Einzelobjektart == #Landungssteg) => ((objectCount(Flaechenelement) > 0) AND (objectCount(Linienelement) == 0) AND (objectCount(Punktelement) == 0))
+                (Einzelobjektart == #Landungssteg) => (objectCount(Punktelement) == 0)
             );
 
             !!@ ilivalid.msg="Bei Art=unterirdisches Gebaeude darf die Geometrie nicht in Punktelement sein";
@@ -349,12 +349,12 @@ IMPORTS DMAV_Gebaeudeadressen_V1_0;
                 (Einzelobjektart == #Schwelle) => (objectCount(Punktelement) == 0)
             );
 
-            !!@ ilivalid.msg="Bei Art=Lawinenverbauung muss die Geometrie in Linienelement sein";
+            !!@ ilivalid.msg="Bei Art=Lawinenverbauung darf die Geometrie nicht in Punktelement sein";
             !!@ ilivalid.msg_de="Bei Art=Lawinenverbauung muss die Geometrie in Linienelement sein";
             !!@ ilivalid.msg_fr="Pour les objets du Genre=paravalanche, il faut définir la géométrie dans la table Element_lineaire";
             !!@ ilivalid.msg_it="Per il genere riparo_antivalanghe la geometria deve essere del tipo elemento lineare";
             MANDATORY CONSTRAINT CH052164: (
-                (Einzelobjektart == #Lawinenverbauung) => ((objectCount(Flaechenelement) == 0) AND (objectCount(Linienelement) > 0) AND (objectCount(Punktelement) == 0))
+                (Einzelobjektart == #Lawinenverbauung) => (objectCount(Punktelement) == 0)
             );
 
             !!@ ilivalid.msg="Bei Art=massiver_Sockel darf die Geometrie nicht in Punktelement sein";
@@ -396,7 +396,16 @@ IMPORTS DMAV_Gebaeudeadressen_V1_0;
             MANDATORY CONSTRAINT CH052178: (
                 (Einzelobjektart == #uebriger_Gebaeudeteil) => (objectCount(Punktelement) == 0)
             );
-
+			
+		    !!@ ilivalid.msg="Bei Art=Jauchengrube_Mistlege darf die Geometrie nicht in Punktelement sein";
+            !!@ ilivalid.msg_de="Bei Art=Jauchengrube_Mistlege darf die Geometrie nicht in Punktelement sein";
+            !!@ ilivalid.msg_fr="Pour les objets du Genre=fosse_purin_tas_fumier, la géométrie ne peut pas être définie dans la table Element_ponctuel";
+            !!@ ilivalid.msg_it="Per il genere Pozzo nero la geometria non deve essere del tipo puntiforme";
+            MANDATORY CONSTRAINT CH052178: (
+                (Einzelobjektart == #Jauchengrube_Mistlege) => (objectCount(Punktelement) == 0)
+            );
+			
+			!! TODO: Landungssteg ... umhüllend eine Fläche. Linien dürfen nur innerhalb der Fläche sein. Neue Anforderung noch keine CheckID
             !! TODO: CH054351
 
         END v_Einzelobjekt;


### PR DESCRIPTION
E-Mail swisstopo:

- Unterirdische Gebäude darf beim CheckDMAV Fläche und Linien sein. Bei Modelldoku nur Fläche.
Test ist richtig (Abschwächung wegen kantonaler Unterschiede) -> also Fläche und Linien sind erlaubt

- Lawinenverbauung darf beim CheckDMAV nur Linie sein. Bei Modelldoku Fläche und Linie. 
Der Test ist richtig, er prüft nur ob es Objekte bei den Punkten hat. Der Fehlertext ist aber falsch und muss korrigiert werden (Bei Art= Lawinenverbauung darf die Geometrie nicht in Tab. Punktelement sein)

- Landungssteg darf beim CheckDMAV nur Fläche sein. Bei Modelldoku Fläche und Linie.
Der Test sollte umgebaut so werden, dass die Umhüllende eine Fläche ist, innerhalb es aber Linien haben darf. Dies wurde offenbar noch nicht umgesetzt.

- Jauchegrube gibt es keinen Constraint. Bei Modelldoku nur Fläche?
Da es im DM01 keine Jauchegrube, Mistlegen gab, gibt es hier keinen Test. Es gibt hier bei den Kantonen sicher auch Linienelemente. Bisher ist kein Test vorgesehen
